### PR TITLE
Add API versioning using RouteGroups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/alexedwards/argon2id v0.0.0-20200522061839-9369edc04b05
+	github.com/arkn98/httprouter v1.4.1
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/go-ozzo/ozzo-validation/v4 v4.2.1
@@ -11,7 +12,6 @@ require (
 	github.com/jackc/pgx/v4 v4.6.0
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/jordan-wright/email v0.0.0-20200602115436-fd8a7622303e
-	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.5.2 // indirect
 	github.com/mediocregopher/radix/v3 v3.5.1
 	github.com/spf13/viper v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexedwards/argon2id v0.0.0-20200522061839-9369edc04b05 h1:votg1faEmwABhCeJ4tiBrvwk4BWftQGkEtFy5iuI7rU=
 github.com/alexedwards/argon2id v0.0.0-20200522061839-9369edc04b05/go.mod h1:GFtu6vaWaRJV5EvSFaVqgq/3Iq95xyYElBV/aupGzUo=
+github.com/arkn98/httprouter v1.4.1 h1:Z4kCKqo+sNqgLWsLsG8/4vqw3alwlQSZvfUI02213DA=
+github.com/arkn98/httprouter v1.4.1/go.mod h1:Km2MJZriSHWpYgBo2Z3m9QoH6SxWW97xOP0QqB5ZX38=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -176,8 +178,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/internal/api/route/route.go
+++ b/internal/api/route/route.go
@@ -5,7 +5,7 @@ import (
 
 	"adeia-api/internal/api/middleware"
 
-	"github.com/julienschmidt/httprouter"
+	"github.com/arkn98/httprouter"
 )
 
 // Route represents an API route containing a path, method, handler and a
@@ -29,7 +29,7 @@ func New(method, path string, handler http.HandlerFunc, middleware middleware.Fu
 
 // BindRoutes binds/mounts the provided routes to the router and, also composes
 // (adds) all the middleware funcs (in order) to the handler.
-func BindRoutes(router *httprouter.Router, routes []*Route) {
+func BindRoutes(router *httprouter.RouteGroup, routes []*Route) {
 	for _, route := range routes {
 		handler := route.Handler
 

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -10,9 +10,9 @@ import (
 	"adeia-api/internal/util"
 	"adeia-api/internal/util/crypto"
 
+	"github.com/arkn98/httprouter"
 	"github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"
-	"github.com/julienschmidt/httprouter"
 )
 
 // UserRoutes returns a slice containing all user-related routes.

--- a/internal/util/constants/constants.go
+++ b/internal/util/constants/constants.go
@@ -1,6 +1,9 @@
 package constants
 
 const (
+	// APIVersion represents the current major version of the API.
+	APIVersion = "v1"
+
 	// EmployeeIDLength represents the length of the generated employee IDs.
 	EmployeeIDLength = 6
 


### PR DESCRIPTION
The author of `httprouter` in currently inactive and, a PR for adding route groups to `httprouter` is pending for about 5 years now. So, I forked it, added the contents of that existing PR and tagged a new release. So, `github.com/arkn98/httprouter` will be a drop-in replacement for `github.com/julienschmidt/httprouter` with the additional route groups feature.